### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/jekyll-build-pr.yml
+++ b/.github/workflows/jekyll-build-pr.yml
@@ -1,5 +1,8 @@
 name: Jekyll Build Pull Requests
 
+permissions:
+  contents: read
+
 on: 
   pull_request:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/A9G-Data-Droid/A9G-Data-Droid.github.io/security/code-scanning/5](https://github.com/A9G-Data-Droid/A9G-Data-Droid.github.io/security/code-scanning/5)

In general, fix this by explicitly defining a `permissions` block that grants only the minimum required scopes, either at the workflow root (applies to all jobs) or under the specific job. For this workflow, the build job only needs to read the repository contents to run `actions/checkout` and build the site; it does not push changes or manage PRs. Therefore `contents: read` at the workflow level is sufficient and follows the CodeQL suggestion.

Concretely, in `.github/workflows/jekyll-build-pr.yml`, add a `permissions:` section near the top of the file (after `name:` or after `on:`) that sets `contents: read`. This will apply to the `build` job because it does not have its own `permissions` block. No other changes, imports, or new methods are required, and existing workflow behavior will be unchanged except for the token being restricted to read-only repository contents.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
